### PR TITLE
Update benchmark to 2.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "quick and dirty benchmark.js wrapper",
   "main": "index.js",
   "dependencies": {
-    "benchmark": "^1.0.0"
+    "benchmark": "^2.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
[Changes between 1.0.0 and 2.0.0](https://github.com/bestiejs/benchmark.js/compare/e9667c4ee926baa938e54565260335da67bc5561...ba3105deea518d45bfb8c0e183f7baa92d8abef9)

A simple test repo does still work after updating, but due to the length of time/commits/etc between 1.0.0 and 2.0.0 (and lack of `CHANGELOG.md`) I am not 100% certain that this isn't a breaking change for consumers of `do-you-even-bench`.  Probably best to release as 2.0.0 just to be safe?
